### PR TITLE
feature: 게시물 상세 및 고정 게시물 목록 조회 시 category_id 추가

### DIFF
--- a/blog/serializers/post_serializers.py
+++ b/blog/serializers/post_serializers.py
@@ -7,6 +7,11 @@ from blog.models import Post
 class PostDetailSerializer(serializers.ModelSerializer):
 
     post_id = serializers.IntegerField(source="id")
+    category_id = relations.SlugRelatedField(
+        source="category",
+        slug_field="id",
+        read_only=True
+    )
     category_name = relations.SlugRelatedField(
         source="category",
         slug_field="name",
@@ -17,6 +22,7 @@ class PostDetailSerializer(serializers.ModelSerializer):
         model = Post
         fields = [
             "post_id",
+            "category_id",
             "category_name",
             "title",
             "subtitle",
@@ -38,6 +44,7 @@ class PostListSerializer(serializers.ModelSerializer):
         model = Post
         fields = [
             "post_id",
+            "category_id",
             "category_name",
             "title",
             "description",
@@ -47,6 +54,11 @@ class PostListSerializer(serializers.ModelSerializer):
 class TopPostListSerializer(serializers.ModelSerializer):
 
     post_id = serializers.IntegerField(source="id")
+    category_id = relations.SlugRelatedField(
+        source="category",
+        slug_field="id",
+        read_only=True
+    )
     category_name = relations.SlugRelatedField(
         source="category",
         slug_field="name",
@@ -57,6 +69,7 @@ class TopPostListSerializer(serializers.ModelSerializer):
         model = Post
         fields = [
             "post_id",
+            "category_id",
             "category_name",
             "title",
             "subtitle",

--- a/blog/serializers/post_serializers.py
+++ b/blog/serializers/post_serializers.py
@@ -4,8 +4,7 @@ from rest_framework import serializers
 from blog.models import Post
 
 
-class PostDetailSerializer(serializers.ModelSerializer):
-
+class BasePostSerializer(serializers.ModelSerializer):
     post_id = serializers.IntegerField(source="id")
     category_id = relations.SlugRelatedField(
         source="category",
@@ -20,6 +19,12 @@ class PostDetailSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Post
+        fields = []
+
+
+class PostDetailSerializer(BasePostSerializer):
+
+    class Meta(BasePostSerializer.Meta):
         fields = [
             "post_id",
             "category_id",
@@ -31,42 +36,21 @@ class PostDetailSerializer(serializers.ModelSerializer):
         ]
 
 
-class PostListSerializer(serializers.ModelSerializer):
+class PostListSerializer(BasePostSerializer):
 
-    post_id = serializers.IntegerField(source="id")
-    category_name = relations.SlugRelatedField(
-        source="category",
-        slug_field="name",
-        read_only=True
-    )
-
-    class Meta:
-        model = Post
+    class Meta(BasePostSerializer.Meta):
         fields = [
             "post_id",
-            "category_id",
             "category_name",
             "title",
             "description",
             "preview_image",
         ]
 
-class TopPostListSerializer(serializers.ModelSerializer):
 
-    post_id = serializers.IntegerField(source="id")
-    category_id = relations.SlugRelatedField(
-        source="category",
-        slug_field="id",
-        read_only=True
-    )
-    category_name = relations.SlugRelatedField(
-        source="category",
-        slug_field="name",
-        read_only=True
-    )
+class TopPostListSerializer(BasePostSerializer):
 
-    class Meta:
-        model = Post
+    class Meta(BasePostSerializer.Meta):
         fields = [
             "post_id",
             "category_id",

--- a/blog/tests/post_views_test.py
+++ b/blog/tests/post_views_test.py
@@ -45,6 +45,7 @@ class TestPostDetailView:
         # then
         assert response.status_code == 200
         assert response.data["post_id"] == post.id
+        assert response.data["category_id"] == category.id
         assert response.data["category_name"] == category.name
         assert response.data["title"] == post.title
         assert response.data["subtitle"] == post.subtitle
@@ -226,11 +227,11 @@ class TestTopPostListView:
         assert response.status_code == 200
         assert len(response.data) == 1
         assert response.data[0]["post_id"] == post1.id
+        assert response.data[0]["category_id"] == category.id
         assert response.data[0]["category_name"] == category.name
         assert response.data[0]["title"] == post1.title
         assert response.data[0]["subtitle"] == post1.subtitle
         assert POST_IMAGE_UPLOAD_PATH in response.data[0]["preview_image"]
-
 
     def test_retrieve_top_posts_order_by_sort_order(self):
         # given


### PR DESCRIPTION
## 연관된 이슈

- close #19 

## 작업 내용
### 응답 json에 category_id 필드 추가

원본 데일리펀딩 블로그를 확인해보면 `게시물 상세` 및 `고정 게시물 목록`에서 `카테고리명`을 클릭하면
해당 카테고리가 필터링된 게시물 목록을 조회하도록 동작합니다.
해당 api 스펙에 `category_id`가 없어 이를 추가하였습니다.

구현 방법으로는
- category를 하나의 json 객체로 감싸는 것
- `category_id`와 `category_name`으로 flat하게 표현하는 것

이 두가지 중에서
```
현재 프론트 구현 기준으로는 category_id, category_name을 바로 쓰는 after2가 조금 더 단순해서 저는 after2가 더 편합니다.
```
라는 프론트 개발자의 의견에 따라 후자를 선택했습니다.

**상세 조회**
<img width="528" height="320" alt="image" src="https://github.com/user-attachments/assets/1564a22e-f0ab-4c7f-b4ed-5ed020e75729" />

**고정 게시물 목록 조회**
<img width="594" height="562" alt="image" src="https://github.com/user-attachments/assets/cc08c77e-d35d-4990-a0a4-b35f2cda0ce0" />

---
### BasePostSerializer 분리

대부분의 post serializer 내에서 다음 코드가 반복되는 것을 발견하였습니다.
```
    post_id = serializers.IntegerField(source="id")
    category_id = relations.SlugRelatedField(
        source="category",
        slug_field="id",
        read_only=True
    )
    category_name = relations.SlugRelatedField(
        source="category",
        slug_field="name",
        read_only=True
    )

    class Meta:
        model = Post
```

재사용성과 가독성을 높이고자 `BasePostSerializer`로 분리했습니다.

각 serializer는 `BasePostSerializer`를 상속받고 직렬화 필드만 다르게 선언하면 됩니다.
<img width="553" height="368" alt="image" src="https://github.com/user-attachments/assets/9e2cfd35-e741-4f5c-b343-6fc47a2ddd7e" />
<img width="496" height="529" alt="image" src="https://github.com/user-attachments/assets/49f2b577-ecbd-4e81-9fe6-1336e487a01d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 게시물 상세정보 및 인기 게시물 응답에 카테고리 ID가 추가되었습니다. 이제 API 응답을 통해 각 게시물의 카테고리 정보를 더 쉽게 확인할 수 있습니다.

* **테스트**
  * 새로운 카테고리 ID 필드에 대한 검증 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->