### PR TITLE
feature: 인사이트 게시물 목록 조회

### DIFF
--- a/blog/serializers/post_serializers.py
+++ b/blog/serializers/post_serializers.py
@@ -59,3 +59,14 @@ class TopPostListSerializer(BasePostSerializer):
             "subtitle",
             "preview_image",
         ]
+
+
+class InsightPostSerializer(BasePostSerializer):
+
+    class Meta(BasePostSerializer.Meta):
+        fields = [
+            "post_id",
+            "category_name",
+            "title",
+            "preview_image",
+        ]

--- a/blog/tests/post_views_test.py
+++ b/blog/tests/post_views_test.py
@@ -318,7 +318,28 @@ class TestInsightPostListView:
         client = APIClient()
 
         # when
-        response = client.get(f"/posts/999/insight/")
+        response = client.get("/posts/999/insight/")
 
         # then
         assert response.status_code == 404
+
+    def test_return_less_than_six_posts_when_not_enough(self):
+        # given
+        client = APIClient()
+        user = create_user()
+        category = create_category()
+        preview_image = SimpleUploadedFile(
+            name="test.jpg",
+            content=b"fake image content",
+            content_type="image/jpeg",
+        )
+        post1 = create_post(category=category, preview_image=preview_image, author=user)
+        post2 = create_post(category=category, preview_image=preview_image, author=user)
+
+        # when
+        response = client.get(f"/posts/{post1.id}/insight/")
+
+        # then
+        assert response.status_code == 200
+        assert len(response.data["posts"]) == 1
+        assert response.data["posts"][0]["post_id"] == post2.id

--- a/blog/tests/post_views_test.py
+++ b/blog/tests/post_views_test.py
@@ -311,7 +311,7 @@ class TestInsightPostListView:
         assert response.data["posts"][3]["post_id"] == post6.id
         assert response.data["posts"][4]["post_id"] == post5.id
         assert response.data["posts"][5]["post_id"] == post2.id
-        assert (post["post_id"] != post4.id for post in response.data["posts"])
+        assert all(post["post_id"] != post4.id for post in response.data["posts"])
 
     def test_raise_404_when_not_exists_post(self):
         # given

--- a/blog/tests/post_views_test.py
+++ b/blog/tests/post_views_test.py
@@ -232,7 +232,6 @@ class TestTopPostListView:
         assert response.data["posts"][0]["subtitle"] == post1.subtitle
         assert POST_IMAGE_UPLOAD_PATH in response.data["posts"][0]["preview_image"]
 
-
     def test_retrieve_top_posts_order_by_sort_order(self):
         # given
         client = APIClient()
@@ -262,3 +261,53 @@ class TestTopPostListView:
         assert response.data["posts"][1]["post_id"] == post3.id
         assert response.data["posts"][2]["post_id"] == post4.id
         assert response.data["posts"][3]["post_id"] == post2.id
+
+@pytest.mark.django_db
+class TestInsightPostListView:
+
+    def test_retrieve_insight_posts(self):
+        # given
+        client = APIClient()
+        user = create_user()
+        category1 = create_category()
+        category2 = create_category()
+        preview_image = SimpleUploadedFile(
+            name="test.jpg",
+            content=b"fake image content",
+            content_type="image/jpeg",
+        )
+        with freeze_time("2024-01-01 00:00:00"):
+            post1 = create_post(category=category1, preview_image=preview_image, author=user)
+        with freeze_time("2024-01-02 00:00:00"):
+            post2 = create_post(category=category1, preview_image=preview_image, author=user)
+        with freeze_time("2024-01-03 00:00:00"):
+            post3 = create_post(category=category1, preview_image=preview_image, author=user)
+        with freeze_time("2024-01-04 00:00:00"):
+            post4 = create_post(category=category2, preview_image=preview_image, author=user)
+        with freeze_time("2024-01-05 00:00:00"):
+            post5 = create_post(category=category1, preview_image=preview_image, author=user)
+        with freeze_time("2024-01-06 00:00:00"):
+            post6 = create_post(category=category1, preview_image=preview_image, author=user)
+        with freeze_time("2024-01-07 00:00:00"):
+            post7 = create_post(category=category1, preview_image=preview_image, author=user)
+        with freeze_time("2024-01-08 00:00:00"):
+            post8 = create_post(category=category1, preview_image=preview_image, author=user)
+        with freeze_time("2024-01-09 00:00:00"):
+            post9 = create_post(category=category1, preview_image=preview_image, author=user)
+
+        # when
+        response = client.get(f"/posts/{post3.id}/insight/")
+
+        # then
+        """
+        다른 카테고리인 post4, 본 게시물인 post3은 필터링된다.
+        post1는 최신순 6개에 들지 않아 제외된다.
+        """
+        assert response.status_code == 200
+        assert len(response.data["posts"]) == 6
+        assert response.data["posts"][0]["post_id"] == post9.id
+        assert response.data["posts"][1]["post_id"] == post8.id
+        assert response.data["posts"][2]["post_id"] == post7.id
+        assert response.data["posts"][3]["post_id"] == post6.id
+        assert response.data["posts"][4]["post_id"] == post5.id
+        assert response.data["posts"][5]["post_id"] == post2.id

--- a/blog/tests/post_views_test.py
+++ b/blog/tests/post_views_test.py
@@ -312,3 +312,13 @@ class TestInsightPostListView:
         assert response.data["posts"][4]["post_id"] == post5.id
         assert response.data["posts"][5]["post_id"] == post2.id
         assert (post["post_id"] != post4.id for post in response.data["posts"])
+
+    def test_raise_404_when_not_exists_post(self):
+        # given
+        client = APIClient()
+
+        # when
+        response = client.get(f"/posts/999/insight/")
+
+        # then
+        assert response.status_code == 404

--- a/blog/tests/post_views_test.py
+++ b/blog/tests/post_views_test.py
@@ -311,3 +311,4 @@ class TestInsightPostListView:
         assert response.data["posts"][3]["post_id"] == post6.id
         assert response.data["posts"][4]["post_id"] == post5.id
         assert response.data["posts"][5]["post_id"] == post2.id
+        assert (post["post_id"] != post4.id for post in response.data["posts"])

--- a/blog/tests/post_views_test.py
+++ b/blog/tests/post_views_test.py
@@ -343,3 +343,22 @@ class TestInsightPostListView:
         assert response.status_code == 200
         assert len(response.data["posts"]) == 1
         assert response.data["posts"][0]["post_id"] == post2.id
+
+    def test_return_empty_list_when_only_reference_post_exists(self):
+        # given
+        client = APIClient()
+        user = create_user()
+        category = create_category()
+        preview_image = SimpleUploadedFile(
+            name="test.jpg",
+            content=b"fake image content",
+            content_type="image/jpeg",
+        )
+        post = create_post(category=category, preview_image=preview_image, author=user)
+
+        # when
+        response = client.get(f"/posts/{post.id}/insight/")
+
+        # then
+        assert response.status_code == 200
+        assert len(response.data["posts"]) == 0

--- a/blog/urls/post_urls.py
+++ b/blog/urls/post_urls.py
@@ -3,9 +3,11 @@ from blog.views.post_views import (
     post_list,
     top_post_list,
     post_detail,
+    insight_post_list,
 )
 
 urlpatterns = [
+    path("<int:post_id>/insight/", insight_post_list),
     path("<int:post_id>/", post_detail),
     path("top/", top_post_list),
     path("", post_list),

--- a/blog/views/post_views.py
+++ b/blog/views/post_views.py
@@ -75,8 +75,8 @@ def insight_post_list(request, post_id):
     insight_posts = (
         Post.objects.select_related("category")
         .filter(category=post.category)
-        .exclude(pk=post.pk)
+        .exclude(pk=post.id)
         .order_by("-created_at")[:INSIGHT_POSTS_COUNT]
     )
     serializer = InsightPostSerializer(insight_posts, many=True)
-    return Response(serializer.data)
+    return Response({"posts": serializer.data})

--- a/blog/views/post_views.py
+++ b/blog/views/post_views.py
@@ -76,7 +76,7 @@ def insight_post_list(request, post_id):
         Post.objects.select_related("category")
         .filter(category=post.category)
         .exclude(pk=post.pk)
-        .order_by("-created_at")[INSIGHT_POSTS_COUNT]
+        .order_by("-created_at")[:INSIGHT_POSTS_COUNT]
     )
     serializer = InsightPostSerializer(insight_posts, many=True)
     return Response(serializer.data)

--- a/blog/views/post_views.py
+++ b/blog/views/post_views.py
@@ -1,4 +1,3 @@
-from django.db.models import OuterRef, Subquery
 from django.shortcuts import get_object_or_404
 from rest_framework.decorators import api_view
 from rest_framework.pagination import PageNumberPagination
@@ -10,8 +9,11 @@ from blog.serializers.post_serializers import (
     PostDetailSerializer,
     PostListSerializer,
     TopPostListSerializer,
+    InsightPostSerializer,
 )
 from blog.util.request_parser import get_query_string_filter
+
+INSIGHT_POSTS_COUNT = 6
 
 
 class PostPagination(PageNumberPagination):
@@ -61,3 +63,20 @@ def top_post_list(request):
     pinned_posts = [pin.post for pin in pins]
     serializer = TopPostListSerializer(pinned_posts, many=True)
     return Response({"posts": serializer.data})
+
+
+@api_view(["GET"])
+def insight_post_list(request, post_id):
+    """
+    인사이트 게시물 목록 조회
+    본 게시물을 제외하고 동일 카테고리 내 최신 게시물을 INSIGHT_POSTS_COUNT 개만큼 조회한다.
+    """
+    post = get_object_or_404(Post, pk=post_id)
+    insight_posts = (
+        Post.objects.select_related("category")
+        .filter(category=post.category)
+        .exclude(pk=post.pk)
+        .order_by("-created_at")[INSIGHT_POSTS_COUNT]
+    )
+    serializer = InsightPostSerializer(insight_posts, many=True)
+    return Response(serializer.data)


### PR DESCRIPTION
## 연관된 이슈

- close #32 

## 작업 내용
### 인사이트 게시물 목록 조회 API 구현
**GET /posts/{post_id}/insight/**

- post_id에 해당하는 게시물이 속한 카테고리 내 생성일 기준 최신순 6개 게시물을 조회한다.
- 단, post_id에 해당하는 본 게시물은 포함하지 않는다.

<img width="787" height="492" alt="image" src="https://github.com/user-attachments/assets/8ed9709f-6fbc-4efa-abc1-1c63c7bb2785" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 포스트 상세에서 동일 카테고리의 최신 관련 포스트를 최대 6개까지 반환 — 각 항목에 포스트 ID, 카테고리명, 제목, 미리보기 이미지 포함

* **Tests**
  * 관련 포스트 조회 동작에 대한 테스트 추가(6개 제한, 다른 카테고리 제외, 대상 포스트 미존재/관련 포스트가 적거나 없음 처리)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->