### PR TITLE
feature: 요청/응답 트레이스 로깅 및 환경 별 로깅 구조 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,4 @@ db.sqlite3
 .vscode/settings.json
 
 images/*
-
+logs/*

--- a/config/middlewares/logging_middleware.py
+++ b/config/middlewares/logging_middleware.py
@@ -29,7 +29,7 @@ class LoggingMiddleware:
 
     def _get_client_ip(self, request):
         x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
-        if x_forwarded_for:
+        if x_forwarded_for: # 로드밸런서, 프록시 존재 시 원본 ip 파싱
             return x_forwarded_for.split(",")[0].strip()
         return request.META.get("REMOTE_ADDR", "-")
 

--- a/config/middlewares/logging_middleware.py
+++ b/config/middlewares/logging_middleware.py
@@ -1,0 +1,43 @@
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+
+class LoggingMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        start = time.time()
+        self.do_request_log(request)
+
+        response = self.get_response(request)
+
+        duration = (time.time() - start) * 1000
+        self.do_response_log(duration, request, response)
+
+        return response
+
+    def do_request_log(self, request):
+        logger.info(
+            "REQUEST method=%s path=%s ip=%s",
+            request.method,
+            request.path,
+            self._get_client_ip(request),
+        )
+
+    def _get_client_ip(self, request):
+        x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
+        if x_forwarded_for:
+            return x_forwarded_for.split(",")[0].strip()
+        return request.META.get("REMOTE_ADDR", "-")
+
+    def do_response_log(self, duration, request, response):
+        logger.info(
+            "RESPONSE method=%s path=%s status=%s duration=%.1fms",
+            request.method,
+            request.path,
+            response.status_code,
+            duration,
+        )

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -148,15 +148,19 @@ LOGGING = {
             "format": "[{levelname}] {asctime} {name}: {message}",
             "style": "{",
         },
-    },
-    "handlers": {
-        "console": {
-            "class": "logging.StreamHandler",
-            "formatter": "simple",
+        "medium": {
+            "format": "[{levelname}] [{correlation_id}] {asctime} {name}: {message}",
+            "style": "{",
         },
-    },
-    "root": {
-        "handlers": ["console"],
-        "level": "INFO",
-    },
+    }
+}
+
+DJANGO_GUID = {
+    'GUID_HEADER_NAME': 'Correlation-ID',
+    'VALIDATE_GUID': False,
+    'RETURN_HEADER': True,
+    'EXPOSE_HEADER': True,
+    'INTEGRATIONS': [],
+    'IGNORE_URLS': [],
+    'UUID_LENGTH': 8,
 }

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -33,6 +33,7 @@ INSTALLED_APPS = [
     "ckeditor_uploader",
     "blog",
     "rest_framework",
+    "django_guid",
 ]
 
 CKEDITOR_UPLOAD_PATH = POST_IMAGE_UPLOAD_ROOT
@@ -54,6 +55,8 @@ CKEDITOR_CONFIGS = {
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "django_guid.middleware.guid_middleware",
+    "config.middlewares.logging_middleware.LoggingMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -19,4 +19,26 @@ DATABASES = {
     }
 }
 
+LOGGING["handlers"] = {
+    "console": {
+        "class": "logging.StreamHandler",
+        "formatter": "simple",
+    },
+}
 
+LOGGING["loggers"] = {
+    "django_guid": {
+        "level": "WARNING",
+        "propagate": False,
+    },
+    "blog": {
+        "handlers": ["console"],
+        "level": "DEBUG",
+        "propagate": False,
+    },
+}
+
+LOGGING["root"] = {
+    "handlers": ["console"],
+    "level": "INFO",
+}

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -33,7 +33,7 @@ LOGGING["handlers"] = {
     "file": {
         "class": "logging.handlers.TimedRotatingFileHandler",
         "filename": BASE_DIR / "logs" / "prod.log",
-        "when": "D",
+        "when": "midnight",
         "interval": 1,
         "backupCount": 30,
         "formatter": "medium",

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -17,3 +17,48 @@ DATABASES = {
         "PORT": os.getenv("DB_PORT", "3306"),
     }
 }
+
+LOGGING["filters"] = {
+    "correlation_id": {
+        "()": "django_guid.log_filters.CorrelationId",
+    },
+}
+
+LOGGING["handlers"] = {
+    "console": {
+        "class": "logging.StreamHandler",
+        "formatter": "medium",
+        "filters": ["correlation_id"],
+    },
+    "file": {
+        "class": "logging.handlers.TimedRotatingFileHandler",
+        "filename": BASE_DIR / "logs" / "prod.log",
+        "when": "D",
+        "interval": 1,
+        "backupCount": 30,
+        "formatter": "medium",
+        "filters": ["correlation_id"],
+    }
+}
+
+LOGGING["loggers"] = {
+    "django_guid": {
+        "level": "WARNING",
+        "propagate": False,
+    },
+    "blog": {
+        "handlers": ["console", "file"],
+        "level": "INFO",
+        "propagate": False,
+    },
+    "django.server": {
+        "handlers": ["console"],
+        "level": "WARNING",
+        "propagate": False,
+    },
+}
+
+LOGGING["root"] = {
+    "handlers": ["console", "file"],
+    "level": "INFO",
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,4 @@ typing_extensions==4.15.0
 urllib3==2.6.3
 Werkzeug==3.1.6
 xmltodict==1.0.4
+django-guid==3.5.2


### PR DESCRIPTION
## 연관된 이슈

- close #34

## 작업 내용
### 환경 별 로깅 구조 설정

로컬 환경과 운영 환경의 로깅 설정을 다음과 같이 분리했습니다.

#### local
- blog 하위 : [DEBUG] 콘솔 출력
  - local에서만 확인 가능한 debug 레벨 로그를 통해 개발 중 디버깅을 용이하게 해줍니다.
- root 하위 : [INFO] 콘솔 출력 
<img width="278" height="365" alt="image" src="https://github.com/user-attachments/assets/948d07ed-8b11-4886-8f33-f5c1a6778b4e" />
  
#### prod
- blog 하위 : [INFO] 콘솔/파일 출력
- root 하위 : [INFO] 콘솔/파일 출력
<img width="320" height="476" alt="image" src="https://github.com/user-attachments/assets/7a334c9d-8535-48e4-b4a0-08dcb49ebcab" />

#### 로그 파일 관리
- 프로젝트 루트 디렉토리 내 `logs/` 디렉토리에 로그 파일을 생성합니다.
- 관리 용이성을 높이기 위해 1일 주기로 rotate 하도록 구현했습니다.
- 서버 내 로그 파일 보관 기간은 30일로 설정하였습니다.
  - 추후 로그 파일의 중요성에 대해 논의해본 뒤 보관 기간을 줄이거나 늘려볼 수 있을 것 같습니다.
<img width="473" height="207" alt="image" src="https://github.com/user-attachments/assets/8a120235-96c3-4a46-a2d5-6f7fe8259f83" />

---
### 요청 트레이싱

하나의 요청에서 발생한 로그를 손쉽게 관리할 수 있는 요청 트레이싱을 도입했습니다.
[`django-guid`](https://django-guid.readthedocs.io/en/latest/index.html) 라이브러리를 활용하여 비교적 간단하게 구현했습니다.

설정은 다음과 같습니다.

<img width="335" height="220" alt="image" src="https://github.com/user-attachments/assets/bcc1bd22-afa9-43de-be10-0a2e4039ea2d" />

기능을 요약하자면
- 클라이언트의 요청 헤더로부터 'correlation_id' 파싱
  - 존재하지 않으면 UUID 랜덤 생성
  - UUID 전부를 사용하기에는 로그 가독성이 떨어질 것 같다고 판단해 8자로 제한했습니다.
- 로깅 핸들러가 'correlation_id'를 사용할 수 있도록 요청 컨텍스트에 보관
- 응답 헤더에 'correlation_id' 포함

클라이언트와 로그 `correlation_id`를 주고 받음으로써 서버뿐만 아니라 클라이언트 단까지 로그를 동기화할 수 있습니다.
하나의 요청에서 발생한 모든 로그에 `correlation_id`를 포함하여 요청을 더 면밀하게 추적할 수 있습니다. 

---
### 요청/응답 트레이스 로그

애플리케이션으로 들어오는 요청과 응답을 로깅하기 위해 `LoggingMiddleware`를 구현했습니다.

미들웨어 순서는 `correlation_id`를 관리하는 guid의 MiddleWare 뒤에 배치하여
해당 요청/응답 로그에도 'correlation_id'가 출력되도록 하였습니다.

<img width="505" height="110" alt="image" src="https://github.com/user-attachments/assets/366a29b2-9b97-4829-934b-c249d8810a1d" />

<img width="459" height="321" alt="image" src="https://github.com/user-attachments/assets/fcc0fb0d-fe5a-424b-be5d-3bdb815a783b" />

최종적으로는 다음과 같은 로그가 파일에 보관됩니다.

<img width="1416" height="145" alt="image" src="https://github.com/user-attachments/assets/03d97570-c584-4e02-b475-ca6fca72c599" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 요청/응답 로깅 및 처리시간 기록으로 API 호출 추적 및 성능 분석 강화
  * 상관관계 ID(Correlation-ID) 헤더 지원 및 환경별(개발/운영) 로깅 구성 추가

* **의존성**
  * 요청 추적용 라이브러리 추가 (django-guid)

* **잡무(Chores)**
  * 버전관리 설정 변경: images/ 더 이상 무시되지 않음, logs/ 디렉터리 무시 처리됨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->