### PR TITLE
hotfix: 병합 과정 중 누락된 고정게시물 order_by절 추가

### DIFF
--- a/blog/views/post_views.py
+++ b/blog/views/post_views.py
@@ -58,6 +58,7 @@ def top_post_list(request):
     pins = (
         Pin.objects.select_related("post")
         .select_related("post__category")
+        .order_by("sort_order")
     )
     pinned_posts = [pin.post for pin in pins]
     serializer = TopPostListSerializer(pinned_posts, many=True)


### PR DESCRIPTION
## 연관된 이슈

- close #

## 작업 내용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 고정된 게시물 목록이 지정된 정렬 순서에 따라 일관되게 표시되도록 개선했습니다. 이전에는 데이터베이스의 기본 정렬에 의존하고 있었지만, 이제 명시적인 정렬 기준을 적용하여 항상 올바른 순서로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->